### PR TITLE
Remove reference to non-existent file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "ahmadnassri/metalsmith-jade",
   "license": "MIT",
   "main": "src/index.js",
-  "bin": "bin/unnamed",
   "keywords": [
     "metalsmith",
     "plugin",


### PR DESCRIPTION
npm does not install this package if reference exists.
