### PR TITLE
Fix extname check to convert Jade files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ function plugin (options) {
     Object.keys(files).forEach(function (file) {
       debug('checking file: %s', file)
 
-      if (/\.jade/.test(path.extname(file))) {
+      if (!/\.jade/.test(path.extname(file))) {
         return
       }
 


### PR DESCRIPTION
When I tried to convert Jade files with this plugin, some files except Jade files converted.
`extname` should match `.jade` extension.
